### PR TITLE
Iron cmiss.c fix for MINGW

### DIFF
--- a/src/cmiss_c.c
+++ b/src/cmiss_c.c
@@ -59,14 +59,18 @@ void cmfe_SetFatalHandler(void);
 void cmfe_InitFatalHandler(void);
 
 /* Internal functions */
-static void cmfe_FatalHandler(int sig,
-#  if defined (sun)
-                         siginfo_t *sip,
-                         ucontext_t *uap);
-#  else
-			 int code,
-			 struct sigcontext *sc);
-#  endif
+static void cmfe_FatalHandler(int sig
+#if defined (sun)
+	,siginfo_t *sip,
+    ucontext_t *uap);
+#else
+	#ifndef __MINGW32__
+		,int code,
+		struct sigcontext *sc);
+	#else
+		);
+	#endif
+#endif
 
 /* Static variables */
 
@@ -180,16 +184,16 @@ void cmfe_SetFatalHandler(void)
 #endif /* defined (unix) || defined (_AIX) */
 }
 
-static void cmfe_FatalHandler(int sig,
-#  if defined (sun)
-             siginfo_t *sip,
+static void cmfe_FatalHandler(int sig
+#if defined (sun)
+             ,siginfo_t *sip,
              ucontext_t *uap)
 #else
 #ifndef __MINGW32__
-			 int code,
+			 ,int code,
 			 struct sigcontext *sc)
 #else
-		)
+			 )
 #endif
 #endif
 {


### PR DESCRIPTION
this is a simple syntax fix for mingw builds. iron builds with it without complications.

i have no idea yet if the replacements i've put in place make true sense for windows environments and error propagation.. this was a "quick" fix to make iron build in the first place.
someone with more experience should/could have a look into that?
