### PR TITLE
Set the linker language for the FieldML_IO tests to Fortran.

### DIFF
--- a/tests/FieldML_IO/CMakeLists.txt
+++ b/tests/FieldML_IO/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(COPY input/ DESTINATION input)
 add_executable(FieldML_IO fieldml_io.f90 cube.f90 fieldml_arguments.f90 ../Utilities/testframework.f90)
+set_target_properties(FieldML_IO PROPERTIES LINKER_LANGUAGE Fortran)
 target_link_libraries(FieldML_IO iron)
 oc_add_test(FieldML_IO FieldML_IO)


### PR DESCRIPTION
Force the linker language to be Fortran as it doesn't always get picked up from the .f90 file in the target.
