### PR TITLE
Set number of iterations for time loop

### DIFF
--- a/src/control_loop_routines.f90
+++ b/src/control_loop_routines.f90
@@ -970,6 +970,13 @@ CONTAINS
             CALL FlagError(LOCAL_ERROR,ERR,ERROR,*999)
           ENDIF
           TIME_LOOP%NUMBER_OF_ITERATIONS=NUMBER_OF_ITERATIONS
+          
+          !Update time increment if number of iterations differs from time stepping settings
+          IF (CEILING((TIME_LOOP%STOP_TIME-TIME_LOOP%START_TIME)/TIME_LOOP%TIME_INCREMENT) &
+            & /= TIME_LOOP%NUMBER_OF_ITERATIONS) THEN
+            TIME_LOOP%TIME_INCREMENT = (TIME_LOOP%STOP_TIME-TIME_LOOP%START_TIME)/TIME_LOOP%NUMBER_OF_ITERATIONS
+          ENDIF
+          
         ELSE
           CALL FlagError("Control loop time loop is not associated.",ERR,ERROR,*999)
         ENDIF

--- a/src/control_loop_routines.f90
+++ b/src/control_loop_routines.f90
@@ -961,25 +961,21 @@ CONTAINS
     ENTERS("CONTROL_LOOP_NUMBER_OF_ITERATIONS_SET",ERR,ERROR,*999)
 
     IF(ASSOCIATED(CONTROL_LOOP)) THEN
-      IF(CONTROL_LOOP%CONTROL_LOOP_FINISHED) THEN
-        CALL FlagError("Control loop has been finished.",ERR,ERROR,*999)
-      ELSE
-        IF(CONTROL_LOOP%LOOP_TYPE==PROBLEM_CONTROL_TIME_LOOP_TYPE) THEN
-          TIME_LOOP=>CONTROL_LOOP%TIME_LOOP
-          IF(ASSOCIATED(TIME_LOOP)) THEN
-            IF(NUMBER_OF_ITERATIONS<0) THEN
-              LOCAL_ERROR="The specified number of iterations of "//TRIM(NUMBER_TO_VSTRING(NUMBER_OF_ITERATIONS,"*",ERR,ERROR))// &
-                & " is invalid. The number must be non-negative."
-              CALL FlagError(LOCAL_ERROR,ERR,ERROR,*999)
-            ENDIF
-            TIME_LOOP%NUMBER_OF_ITERATIONS=NUMBER_OF_ITERATIONS
-          ELSE
-            CALL FlagError("Control loop time loop is not associated.",ERR,ERROR,*999)
+      IF(CONTROL_LOOP%LOOP_TYPE==PROBLEM_CONTROL_TIME_LOOP_TYPE) THEN
+        TIME_LOOP=>CONTROL_LOOP%TIME_LOOP
+        IF(ASSOCIATED(TIME_LOOP)) THEN
+          IF(NUMBER_OF_ITERATIONS<0) THEN
+            LOCAL_ERROR="The specified number of iterations of "//TRIM(NUMBER_TO_VSTRING(NUMBER_OF_ITERATIONS,"*",ERR,ERROR))// &
+              & " is invalid. The number must be non-negative."
+            CALL FlagError(LOCAL_ERROR,ERR,ERROR,*999)
           ENDIF
+          TIME_LOOP%NUMBER_OF_ITERATIONS=NUMBER_OF_ITERATIONS
         ELSE
-          CALL FlagError("The specified control loop is not a time control loop.",ERR,ERROR,*999)
+          CALL FlagError("Control loop time loop is not associated.",ERR,ERROR,*999)
         ENDIF
-      ENDIF          
+      ELSE
+        CALL FlagError("The specified control loop is not a time control loop.",ERR,ERROR,*999)
+      ENDIF
     ELSE
       CALL FlagError("Control loop is not associated.",ERR,ERROR,*999)
     ENDIF

--- a/src/control_loop_routines.f90
+++ b/src/control_loop_routines.f90
@@ -1635,6 +1635,7 @@ CONTAINS
           TIME_LOOP%START_TIME=START_TIME
           TIME_LOOP%STOP_TIME=STOP_TIME
           TIME_LOOP%TIME_INCREMENT=TIME_INCREMENT
+          TIME_LOOP%NUMBER_OF_ITERATIONS=0    ! reset number of iterations
         ELSE
           CALL FlagError("Control loop time loop is not associated.",ERR,ERROR,*999)
         ENDIF

--- a/src/opencmiss_iron.f90
+++ b/src/opencmiss_iron.f90
@@ -17657,7 +17657,7 @@ CONTAINS
     CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
     IF(ASSOCIATED(PROBLEM)) THEN
       CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifier,CONTROL_LOOP,err,error,*999)
-      CALL CONTROL_LOOP_TIMES_GET(CONTROL_LOOP,startTime,stopTime,timeIncrement,currentTime, &
+      CALL CONTROL_LOOP_TIMES_GET(CONTROL_LOOP,startTime,stopTime,currentTime,timeIncrement, &
         & currentLoopIteration,outputIterationNumber,err,error,*999)
     ELSE
       localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
@@ -17703,7 +17703,7 @@ CONTAINS
     CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
     IF(ASSOCIATED(PROBLEM)) THEN
       CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifiers,CONTROL_LOOP,err,error,*999)
-      CALL CONTROL_LOOP_TIMES_GET(CONTROL_LOOP,startTime,stopTime,timeIncrement,currentTime, &
+      CALL CONTROL_LOOP_TIMES_GET(CONTROL_LOOP,startTime,stopTime,currentTime,timeIncrement, &
         & currentLoopIteration,outputIterationNumber,err,error,*999)
    ELSE
       localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
@@ -17740,7 +17740,7 @@ CONTAINS
 
     ENTERS("cmfe_ControlLoop_TimesGetObj",err,error,*999)
 
-    CALL CONTROL_LOOP_TIMES_GET(controlLoop%controlLoop,startTime,stopTime,timeIncrement,currentTime, &
+    CALL CONTROL_LOOP_TIMES_GET(controlLoop%controlLoop,startTime,stopTime,currentTime,timeIncrement, &
       & currentLoopIteration,outputIterationNumber,err,error,*999)
 
     EXITS("cmfe_ControlLoop_TimesGetObj")

--- a/src/opencmiss_iron.f90
+++ b/src/opencmiss_iron.f90
@@ -1411,6 +1411,20 @@ MODULE OpenCMISS_Iron
     MODULE PROCEDURE cmfe_ControlLoop_AbsoluteToleranceSetObj
   END INTERFACE cmfe_ControlLoop_AbsoluteToleranceSet
 
+  !>Returns the number of iterations for a time control loop. If the returned value is 0, that means that the number has not yet been computed. 
+  INTERFACE cmfe_ControlLoop_NumberOfIterationsGet
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsGetNumber0
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsGetNumber1
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsGetObj
+  END INTERFACE cmfe_ControlLoop_NumberOfIterationsGet
+
+  !>Sets/changes the number of iterations for a time control loop. If set to 0, it will be computed from time increment and start/stop time
+  INTERFACE cmfe_ControlLoop_NumberOfIterationsSet
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsSetNumber0
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsSetNumber1
+    MODULE PROCEDURE cmfe_ControlLoop_NumberOfIterationsSetObj
+  END INTERFACE cmfe_ControlLoop_NumberOfIterationsSet
+
   !>Returns the number of sub loops for a control loop.
   INTERFACE cmfe_ControlLoop_NumberOfSubLoopsGet
     MODULE PROCEDURE cmfe_ControlLoop_NumberOfSubLoopsGetNumber0
@@ -1492,6 +1506,8 @@ MODULE OpenCMISS_Iron
 
   PUBLIC cmfe_ControlLoop_AbsoluteToleranceSet
 
+  PUBLIC cmfe_ControlLoop_NumberOfIterationsGet, cmfe_ControlLoop_NumberOfIterationsSet
+  
   PUBLIC cmfe_ControlLoop_NumberOfSubLoopsGet,cmfe_ControlLoop_NumberOfSubLoopsSet
 
   PUBLIC cmfe_ControlLoop_OutputTypeGet,cmfe_ControlLoop_OutputTypeSet
@@ -17000,6 +17016,214 @@ CONTAINS
     RETURN
 
   END SUBROUTINE cmfe_ControlLoop_AbsoluteToleranceSetObj
+
+  !
+  !================================================================================================================================
+  !
+  
+  !>Gets the number of iterations for a time control loop identified by user number.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetNumber0(problemUserNumber,controlLoopIdentifier,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsGetNumber0)
+
+    !Argument variables
+    INTEGER(INTG), INTENT(IN) :: problemUserNumber !<The user number of the problem to get the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: controlLoopIdentifier !<The control loop identifier.
+    INTEGER(INTG), INTENT(OUT) :: numberOfIterations !<The number of iterations
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+    TYPE(CONTROL_LOOP_TYPE), POINTER :: CONTROL_LOOP
+    TYPE(PROBLEM_TYPE), POINTER :: PROBLEM
+    TYPE(VARYING_STRING) :: localError
+
+    ENTERS("cmfe_ControlLoop_NumberOfItGetNumber0",err,error,*999)  ! name is abbreviated because of maximum line length
+
+    NULLIFY(CONTROL_LOOP)
+    NULLIFY(PROBLEM)
+    CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
+    IF(ASSOCIATED(PROBLEM)) THEN
+      CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifier,CONTROL_LOOP,err,error,*999)
+      CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_GET(CONTROL_LOOP,numberOfIterations,err,error,*999)
+    ELSE
+      localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
+      CALL FlagError(localError,err,error,*999)
+    END IF
+    
+    EXITS("cmfe_ControlLoop_NumberOfItGetNumber0")  ! name is abbreviated because of maximum line length
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfItGetNumber0",err,error)  ! name is abbreviated because of maximum line length
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetNumber0
+
+  !
+  !================================================================================================================================
+  !
+  
+  !>Gets the number of iterations for a time control loop identified by user numbers.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetNumber1(problemUserNumber,controlLoopIdentifiers,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsGetNumber1)
+
+    !Argument variables
+    INTEGER(INTG), INTENT(IN) :: problemUserNumber !<The user number of the problem to get the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: controlLoopIdentifiers(:) !<The control loop identifiers to get the number of iterations for.
+    INTEGER(INTG), INTENT(OUT) :: numberOfIterations !<The number of iterations
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+    TYPE(CONTROL_LOOP_TYPE), POINTER :: CONTROL_LOOP
+    TYPE(PROBLEM_TYPE), POINTER :: PROBLEM
+    TYPE(VARYING_STRING) :: localError
+
+    ENTERS("cmfe_ControlLoop_NumberOfItGetNumber1",err,error,*999)        ! name is abbreviated because of maximum line length
+
+    NULLIFY(CONTROL_LOOP)
+    NULLIFY(PROBLEM)
+    CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
+    IF(ASSOCIATED(PROBLEM)) THEN
+      CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifiers,CONTROL_LOOP,err,error,*999)
+      CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_GET(CONTROL_LOOP,numberOfIterations,err,error,*999)
+    ELSE
+      localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
+      CALL FlagError(localError,err,error,*999)
+    END IF
+
+    EXITS("cmfe_ControlLoop_NumberOfItGetNumber1")        ! name is abbreviated because of maximum line length
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfItGetNumber1",err,error)      ! name is abbreviated because of maximum line length
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetNumber1
+
+  !
+  !================================================================================================================================
+  !
+
+  !>Gets the number of iterations for a time control loop identified by an object.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetObj(controlLoop,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsGetObj)
+
+    !Argument variables
+    TYPE(cmfe_ControlLoopType), INTENT(IN) :: controlLoop !<The control loop to get the number of iterations for.
+    INTEGER(INTG), INTENT(OUT) :: numberOfIterations !<The number of iterations
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+
+    ENTERS("cmfe_ControlLoop_NumberOfIterationsGetObj",err,error,*999)
+
+    CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_GET(controlLoop%controlLoop,numberOfIterations,err,error,*999)
+
+    EXITS("cmfe_ControlLoop_NumberOfIterationsGetObj")
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfIterationsGetObj",err,error)
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsGetObj
+
+  !
+  !================================================================================================================================
+  !
+  
+  !>Sets the number of iterations for a time control loop identified by user number.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetNumber0(problemUserNumber,controlLoopIdentifier,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsSetNumber0)
+
+    !Argument variables
+    INTEGER(INTG), INTENT(IN) :: problemUserNumber !<The user number of the problem to set the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: controlLoopIdentifier !<The control loop identifier.
+    INTEGER(INTG), INTENT(IN) :: numberOfIterations !<The number of iterations to set
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+    TYPE(CONTROL_LOOP_TYPE), POINTER :: CONTROL_LOOP
+    TYPE(PROBLEM_TYPE), POINTER :: PROBLEM
+    TYPE(VARYING_STRING) :: localError
+
+    ENTERS("cmfe_ControlLoop_NumberOfItSetNumber0",err,error,*999)        ! name is abbreviated because of maximum line length
+
+    NULLIFY(CONTROL_LOOP)
+    NULLIFY(PROBLEM)
+    CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
+    IF(ASSOCIATED(PROBLEM)) THEN
+      CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifier,CONTROL_LOOP,err,error,*999)
+      CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_SET(CONTROL_LOOP,numberOfIterations,err,error,*999)
+    ELSE
+      localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
+      CALL FlagError(localError,err,error,*999)
+    END IF
+    
+    EXITS("cmfe_ControlLoop_NumberOfItSetNumber0")        ! name is abbreviated because of maximum line length
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfItSetNumber0",err,error)    ! name is abbreviated because of maximum line length
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetNumber0
+
+  !
+  !================================================================================================================================
+  !
+  
+  !>Sets the number of iterations for a time control loop identified by user numbers.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetNumber1(problemUserNumber,controlLoopIdentifiers,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsSetNumber1)
+
+    !Argument variables
+    INTEGER(INTG), INTENT(IN) :: problemUserNumber !<The user number of the problem to set the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: controlLoopIdentifiers(:) !<The control loop identifiers to set the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: numberOfIterations !<The number of iterations to set
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+    TYPE(CONTROL_LOOP_TYPE), POINTER :: CONTROL_LOOP
+    TYPE(PROBLEM_TYPE), POINTER :: PROBLEM
+    TYPE(VARYING_STRING) :: localError
+
+    ENTERS("cmfe_ControlLoop_NumberOfItSetNumber1",err,error,*999)    ! name is abbreviated because of maximum line length
+
+    NULLIFY(CONTROL_LOOP)
+    NULLIFY(PROBLEM)
+    CALL PROBLEM_USER_NUMBER_FIND(problemUserNumber,PROBLEM,err,error,*999)
+    IF(ASSOCIATED(PROBLEM)) THEN
+      CALL PROBLEM_CONTROL_LOOP_GET(PROBLEM,controlLoopIdentifiers,CONTROL_LOOP,err,error,*999)
+      CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_SET(CONTROL_LOOP,numberOfIterations,err,error,*999)
+    ELSE
+      localError="A problem with an user number of "//TRIM(NumberToVString(problemUserNumber,"*",err,error))//" does not exist."
+      CALL FlagError(localError,err,error,*999)
+    END IF
+
+    EXITS("cmfe_ControlLoop_NumberOfItSetNumber1")    ! name is abbreviated because of maximum line length
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfItSetNumber1",err,error)    ! name is abbreviated because of maximum line length
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetNumber1
+
+  !
+  !================================================================================================================================
+  !
+
+  !>Sets the number of iterations for a time control loop identified by an object.
+  SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetObj(controlLoop,numberOfIterations,err)
+    !DLLEXPORT(cmfe_ControlLoop_NumberOfIterationsSetObj)
+
+    !Argument variables
+    TYPE(cmfe_ControlLoopType), INTENT(IN) :: controlLoop !<The control loop to set the number of iterations for.
+    INTEGER(INTG), INTENT(IN) :: numberOfIterations !<The number of iterations to set
+    INTEGER(INTG), INTENT(OUT) :: err !<The error code.
+    !Local variables
+
+    ENTERS("cmfe_ControlLoop_NumberOfIterationsSetObj",err,error,*999)
+
+    CALL CONTROL_LOOP_NUMBER_OF_ITERATIONS_SET(controlLoop%controlLoop,numberOfIterations,err,error,*999)
+
+    EXITS("cmfe_ControlLoop_NumberOfIterationsSetObj")
+    RETURN
+999 ERRORSEXITS("cmfe_ControlLoop_NumberOfIterationsSetObj",err,error)
+    CALL cmfe_HandleError(err,error)
+    RETURN
+
+  END SUBROUTINE cmfe_ControlLoop_NumberOfIterationsSetObj
 
   !
   !================================================================================================================================

--- a/src/problem_routines.f90
+++ b/src/problem_routines.f90
@@ -548,11 +548,23 @@ CONTAINS
           IF(ASSOCIATED(TIME_LOOP)) THEN
             !Set the current time to be the start time. Solvers should use the first time step to do any initialisation.
             TIME_LOOP%CURRENT_TIME=TIME_LOOP%START_TIME
+            
+            !Precompute the number of iterations from total time span and time increment if it was not specified explicitely 
+            IF (TIME_LOOP%NUMBER_OF_ITERATIONS==0) THEN
+              TIME_LOOP%NUMBER_OF_ITERATIONS=CEILING((TIME_LOOP%STOP_TIME-TIME_LOOP%START_TIME)/TIME_LOOP%TIME_INCREMENT)
+            !If number of iterations was specified but does not match TIME_INCREMENT, e.g. TIME_INCREMENT is still at the default value, compute correct TIME_INCREMENT
+            ELSEIF (CEILING((TIME_LOOP%STOP_TIME-TIME_LOOP%START_TIME)/TIME_LOOP%TIME_INCREMENT) &
+              & /= TIME_LOOP%NUMBER_OF_ITERATIONS) THEN
+              TIME_LOOP%TIME_INCREMENT = (TIME_LOOP%STOP_TIME-TIME_LOOP%START_TIME)/TIME_LOOP%NUMBER_OF_ITERATIONS
+            ENDIF
+            
             TIME_LOOP%ITERATION_NUMBER=0
-            DO WHILE(TIME_LOOP%CURRENT_TIME<TIME_LOOP%STOP_TIME)
+            DO WHILE(TIME_LOOP%ITERATION_NUMBER<TIME_LOOP%NUMBER_OF_ITERATIONS)
               IF(CONTROL_LOOP%OUTPUT_TYPE>=CONTROL_LOOP_PROGRESS_OUTPUT) THEN
                 CALL WRITE_STRING(GENERAL_OUTPUT_TYPE,"",ERR,ERROR,*999)
-                CALL WRITE_STRING_VALUE(GENERAL_OUTPUT_TYPE,"Time control loop iteration: ",TIME_LOOP%ITERATION_NUMBER, &
+                CALL WRITE_STRING_VALUE(GENERAL_OUTPUT_TYPE,"Time control loop iteration:  ",TIME_LOOP%ITERATION_NUMBER, &
+                  & ERR,ERROR,*999)
+                CALL WRITE_STRING_VALUE(GENERAL_OUTPUT_TYPE,"  Total number of iterations: ",TIME_LOOP%NUMBER_OF_ITERATIONS, &
                   & ERR,ERROR,*999)
                 CALL WRITE_STRING_VALUE(GENERAL_OUTPUT_TYPE,"  Current time   = ",TIME_LOOP%CURRENT_TIME, &
                   & ERR,ERROR,*999)

--- a/src/types.f90
+++ b/src/types.f90
@@ -3150,12 +3150,13 @@ END TYPE GENERATED_MESH_ELLIPSOID_TYPE
     INTEGER(INTG) :: ITERATION_NUMBER
     INTEGER(INTG) :: GLOBAL_ITERATION_NUMBER
 ! sebk: is thei usefull?
-    INTEGER(INTG) :: OUTPUT_NUMBER
+    INTEGER(INTG) :: OUTPUT_NUMBER          !< The frequency of output, is only used if the specific problem implementation accesses it
     INTEGER(INTG) :: INPUT_NUMBER
     REAL(DP) :: CURRENT_TIME
     REAL(DP) :: START_TIME
     REAL(DP) :: STOP_TIME
     REAL(DP) :: TIME_INCREMENT
+    INTEGER(INTG) :: NUMBER_OF_ITERATIONS   !< The total number of iterations for this loop, if 0 it will be computed from time span and increment
   END TYPE CONTROL_LOOP_TIME_TYPE
 
   !>Contains information on a do-while control loop


### PR DESCRIPTION
This addresses issue #99.
It adds a new variable `NUMBER_OF_ITERATIONS` for the `CONTROL_LOOP_TIME_TYPE` and getter and setter methods `cmfe_ControlLoop_TimesGet` and `cmfe_ControlLoop_TimesSet`.

By default, `NUMBER_OF_ITERATIONS` has the value 0 and is computed the first time the loop gets executed. If one does not set `NUMBER_OF_ITERATIONS` everything stays the same as usual. If it is set, it overrides the meaning of `TIME_INCREMENT.` If the number of iterations with the given value of `TIME_INCREMENT` would be different from `NUMBER_OF_ITERATIONS`, the value of `TIME_INCREMENT` is updated to the correct new value.